### PR TITLE
PAM controls the position of the prime line/blob

### DIFF
--- a/klipper_macro/pam.cfg
+++ b/klipper_macro/pam.cfg
@@ -1,5 +1,8 @@
 [pam]
 
+pam_controls_prime_position: True   # Whether PAM controls the position of the prime line / blob. Default: True
+prime_offset: 35.0    # Offset from the print area to the start position of the prime line / blob (both x and y). Default 35.0
+
 [gcode_macro _START_PRINT_BED_MESH]
 gcode:
   {% if printer["gcode_macro RatOS"].calibrate_bed_mesh|lower == 'true' %}

--- a/klippy_extra/pam.py
+++ b/klippy_extra/pam.py
@@ -19,8 +19,8 @@ class PAM:
         self.probe_y_step = float((self.bed_mesh.bmc.orig_config['mesh_max'][1] - self.bed_mesh.bmc.orig_config['mesh_min'][1]) / self.bed_mesh.bmc.orig_config['y_count'])
 
     def cmd_MESH_CONFIG(self, param):
-        self.x0 = param.get_float('X0', None, -1000, maxval=1000) 
         self.x0 = param.get_float('X0', None, -1000, maxval=1000)
+        self.y0 = param.get_float('Y0', None, -1000, maxval=1000)
         self.x1 = param.get_float('X1', None, -1000, maxval=1000)
         self.y1 = param.get_float('Y1', None, -1000, maxval=1000)
         if self.x0 < 0 or self.y0 < 0:

--- a/klippy_extra/pam.py
+++ b/klippy_extra/pam.py
@@ -19,8 +19,8 @@ class PAM:
         self.probe_y_step = float((self.bed_mesh.bmc.orig_config['mesh_max'][1] - self.bed_mesh.bmc.orig_config['mesh_min'][1]) / self.bed_mesh.bmc.orig_config['y_count'])
 
     def cmd_MESH_CONFIG(self, param):
+        self.x0 = param.get_float('X0', None, -1000, maxval=1000) 
         self.x0 = param.get_float('X0', None, -1000, maxval=1000)
-        self.y0 = param.get_float('Y0', None, -1000, maxval=1000)
         self.x1 = param.get_float('X1', None, -1000, maxval=1000)
         self.y1 = param.get_float('Y1', None, -1000, maxval=1000)
         if self.x0 < 0 or self.y0 < 0:

--- a/klippy_extra/pam.py
+++ b/klippy_extra/pam.py
@@ -10,6 +10,8 @@ class PAM:
         self.gcode.register_command('PAM', self.cmd_PAM, desc=("PAM"))
         self.gcode.register_command('MESH_CONFIG', self.cmd_MESH_CONFIG, desc=("MESH_CONFIG"))
         self.printer.register_event_handler("klippy:connect", self.handle_connect)
+        self.prime_offset = self.config.getfloat('prime_offset', 35.0)
+        self.pam_controls_prime_position = self.config.get('pam_controls_prime_position', 'True')
 
     def handle_connect(self):
         self.toolhead = self.printer.lookup_object('toolhead')
@@ -17,12 +19,65 @@ class PAM:
         self.probe_y_step = float((self.bed_mesh.bmc.orig_config['mesh_max'][1] - self.bed_mesh.bmc.orig_config['mesh_min'][1]) / self.bed_mesh.bmc.orig_config['y_count'])
 
     def cmd_MESH_CONFIG(self, param):
-        self.x0 = param.get_float('X0', None, -1000, maxval=1000) 
+        self.x0 = param.get_float('X0', None, -1000, maxval=1000)
         self.y0 = param.get_float('Y0', None, -1000, maxval=1000)
         self.x1 = param.get_float('X1', None, -1000, maxval=1000)
         self.y1 = param.get_float('Y1', None, -1000, maxval=1000)
         if self.x0 < 0 or self.y0 < 0:
             self.gcode.respond_raw("Wrong first layer coordinates!")
+        else:
+            if self.pam_controls_prime_position == 'True':
+                self.gcode.respond_raw("PAM: Trying to establish prime line/blob position relative to PAM")
+                ppd = self.find_prime_position()
+                if ppd['x_placed'] and ppd['y_placed']:
+                    self.gcode.respond_raw("PAM: Prime position: x={x}, y={y}. Orientation: {ox}, {oy}, {d}".format(
+                        x=ppd['prime_pos_x'], y=ppd['prime_pos_y'], ox=ppd['orientation_x'], oy=ppd['orientation_y'], d=ppd['prime_direction']))
+                    self.gcode.run_script_from_command("SET_GCODE_VARIABLE MACRO=RatOS VARIABLE=nozzle_prime_start_x "
+                                                       "VALUE={x}".format(x=ppd['prime_pos_x']))
+                    self.gcode.run_script_from_command("SET_GCODE_VARIABLE MACRO=RatOS VARIABLE=nozzle_prime_start_y "
+                                                       "VALUE={y}".format(y=ppd['prime_pos_y']))
+                    self.gcode.run_script_from_command("SET_GCODE_VARIABLE MACRO=RatOS VARIABLE=nozzle_prime_direction "
+                                                       "VALUE=\"\'{d}\'\"".format(d=ppd['prime_direction']))
+                else:
+                    self.gcode.respond_raw("PAM: Can't find a good position for the prime line/blob, using default "
+                                           "position")
+                    self.gcode.run_script_from_command("SET_GCODE_VARIABLE MACRO=RatOS VARIABLE=nozzle_prime_start_x "
+                                                       "VALUE=\"\'max\'\"")
+                    self.gcode.run_script_from_command("SET_GCODE_VARIABLE MACRO=RatOS VARIABLE=nozzle_prime_start_y "
+                                                       "VALUE=\"\'min\'\"")
+                    self.gcode.run_script_from_command("SET_GCODE_VARIABLE MACRO=RatOS VARIABLE=nozzle_prime_direction "
+                                                       "VALUE=\"\'auto\'\"")
+
+    def find_prime_position(self):
+        # Tries to select the best position for the prime blob / line and check if it falls inside the bed
+        ppd = {'x_placed': False, 'y_placed': False}
+        min_x = self.bed_mesh.bmc.orig_config['mesh_min'][0]
+        min_y = self.bed_mesh.bmc.orig_config['mesh_min'][1]
+        max_x = self.bed_mesh.bmc.orig_config['mesh_max'][0]
+        max_y = self.bed_mesh.bmc.orig_config['mesh_max'][1]
+        # select best position for prime line/blob
+        if self.x0 - min_x > max_x - self.x1:
+            ppd['prime_pos_x'] = self.x0 - self.prime_offset   # left
+            ppd['orientation_x'] = 'left'
+        else:
+            ppd['prime_pos_x'] = self.x1 + self.prime_offset   # right
+            ppd['orientation_x'] = 'right'
+        if self.y0 - min_y > max_y - self.y1:
+            ppd['prime_pos_y'] = self.y0 - self.prime_offset   # front
+            ppd['prime_direction'] = 'forwards'
+            ppd['orientation_y'] = 'front'
+        else:
+            ppd['prime_pos_y'] = self.y1 + self.prime_offset   # back
+            ppd['prime_direction'] = 'backwards'
+            ppd['orientation_y'] = 'back'
+        # check that prime line/blob is inside the bed_mesh
+        if min_x < ppd['prime_pos_x'] < max_x:
+            ppd['x_placed'] = True
+        if ppd['prime_direction'] == 'forwards' and ppd['prime_pos_y'] > min_y and ppd['prime_pos_y'] + 100 < max_y:
+            ppd['y_placed'] = True
+        if ppd['prime_direction'] == 'backwards' and ppd['prime_pos_y'] < max_y and ppd['prime_pos_y'] - 100 > min_y:
+            ppd['y_placed'] = True
+        return ppd
 
     def cmd_PAM(self, param):
         if self.x0 >= self.x1 or self.y0 >= self.y1:
@@ -39,6 +94,7 @@ class PAM:
             mesh_cy = min(6, mesh_cy)
         self.gcode.respond_raw("PAM v0.1.0 bed mesh leveling...")
         self.gcode.run_script_from_command('BED_MESH_CALIBRATE PROFILE=ratos mesh_min={0},{1} mesh_max={2},{3} probe_count={4},{5} relative_reference_index=-1'.format(mesh_x0, mesh_y0, mesh_x1, mesh_y1, mesh_cx, mesh_cy))
+
 
 def load_config(config):
     return PAM(config)


### PR DESCRIPTION
With this patch, PAM can control the position of the prime line/blob of RatOS. It uses the first layer coordinates given to the MESH_CONFIG command to find the best place for the prime line/blob. It places the prime feature where there is more room, and the y-axis direction is towards the PAM, so that the prime gets done as close as possible to the measured area to avoid crashes.

It only updates the RatOS macro variables accordingly and let the PRIME macros do their thing, so it should still work even under changes in those macros that don't involve changes in the relevant variables.

Two parameters control the behavior: 
- pam_controls_prime_position -> Whether PAM controls the position of the prime line / blob. 
- prime_offset -> Offset from the print area to the start position of the prime line / blob (both x and y)

It has a simple sanity check and seems to work well in my VC3-500, but if definitely can be much improved. 