### PR TITLE
Round mesh size instead of turncate and use minimum of 4x4 when bicubic

### DIFF
--- a/klippy_extra/pam.py
+++ b/klippy_extra/pam.py
@@ -32,11 +32,19 @@ class PAM:
         mesh_y0 = max(self.y0 - self.offset, self.bed_mesh.bmc.orig_config['mesh_min'][1])
         mesh_x1 = min(self.x1 + self.offset, self.bed_mesh.bmc.orig_config['mesh_max'][0])
         mesh_y1 = min(self.y1 + self.offset, self.bed_mesh.bmc.orig_config['mesh_max'][1])
-        mesh_cx = max(3, int((mesh_x1 - mesh_x0) / self.probe_x_step))
-        mesh_cy = max(3, int((mesh_y1 - mesh_y0) / self.probe_y_step))
-        if self.bed_mesh.bmc.orig_config['algo'] == 'lagrange' or (self.bed_mesh.bmc.orig_config['algo'] == 'bicubic' and (mesh_cx < 4 or mesh_cy < 4)):
-            mesh_cx = min(6, mesh_cx)
-            mesh_cy = min(6, mesh_cy)
+        mesh_cx = max(3, int(0.5 + (mesh_x1 - mesh_x0) / self.probe_x_step))
+        mesh_cy = max(3, int(0.5 + (mesh_y1 - mesh_y0) / self.probe_y_step))
+        
+        # Check the algorithm against the current configuration
+        if self.bed_mesh.bmc.orig_config['algo'] == 'lagrange':
+            # Lagrange interpolation tends to oscillate when using more than 6 samples
+           mesh_cx = min(6, mesh_cx)
+           mesh_cy = min(6, mesh_cy)
+        elif self.bed_mesh.bmc.orig_config['algo'] == 'bicubic':
+            # Bicubic interpolation needs at least 4 samples on each axis
+            mesh_cx = max(4, mesh_cx)
+            mesh_cy = max(4, mesh_cy)
+                        
         self.gcode.respond_raw("PAM v0.1.0 bed mesh leveling...")
         self.gcode.run_script_from_command('BED_MESH_CALIBRATE PROFILE=ratos mesh_min={0},{1} mesh_max={2},{3} probe_count={4},{5} relative_reference_index=-1'.format(mesh_x0, mesh_y0, mesh_x1, mesh_y1, mesh_cx, mesh_cy))
 


### PR DESCRIPTION
2 changes:

- cx and cy is rounded instead of truncated
- klipper defaults to lagrange for meshes smaller than 4x4. I changed the code so respect the original algorithm and guarantee a 4x4 mesh if bicubic was selected.